### PR TITLE
Resizing Fixes and Card 2 Additions

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -39,6 +39,7 @@ body {
     max-width: 800px;
     height: 60vh;
     padding: 1.25rem;
+    overflow-y: auto;
 }
 
 #foreground-container > .card:not(.focus) {
@@ -96,6 +97,7 @@ body {
     flex-direction: row;
     overflow-x: auto;
     width: 100%;
+    max-height: 24vh;
 }
 
 #card-2 .groups > .group {

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,16 +36,16 @@
                     <p>A twitch bot I'm working on. Right now it only queues music.</p>
                 </div>
                 <div class="group">
+                    <h3><a href="https://github.com/PTOS-SPM/PTOS-SPM-Engine/tree/dev" target="_blank">PTOS/SPM Engine</a></h3>
+                    <p>A game engine that I'm helping to make.</p>
+                </div>
+                <div class="group">
                     <h3><a href="https://github.com/SZB3748/Circles" target="_blank">Circles</a></h3>
                     <p>SNS constructed by users out of "Circles". You can think of it like a Euler Diagram where users can create subcircles and post inside of them.</p>
                 </div>
                 <div class="group">
                     <h3><a href="https://github.com/SZB3748/sszzbb.dev" target="_blank">sszzbb.dev</a></h3>
                     <p>This website. It's just a static site so its not that interesting, but just in case you wanted to see the source.</p>
-                </div>
-                <div class="group">
-                    <h3><a href="https://github.com/PTOS-SPM/PTOS-SPM-Engine/tree/dev" target="_blank">PTOS/SPM Engine</a></h3>
-                    <p>A game engine that I'm helping to make.</p>
                 </div>
             </div>
             <b>My Contributions</b>

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
         <div id="card-2" class="card">
             <h1>Github</h1>
             <p>I write a lot of code.</p>
-            <span>Some things I've done:</span>
+            <span>Some of my projects:</span>
             <div class="groups">
                 <div class="group">
                     <h3><a href="https://github.com/SZB3748/SZBot" target="_blank">SZBot</a></h3>
@@ -42,6 +42,10 @@
                 <div class="group">
                     <h3><a href="https://github.com/SZB3748/sszzbb.dev" target="_blank">sszzbb.dev</a></h3>
                     <p>This website. It's just a static site so its not that interesting, but just in case you wanted to see the source.</p>
+                </div>
+                <div class="group">
+                    <h3><a href="https://github.com/PTOS-SPM/PTOS-SPM-Engine/tree/dev" target="_blank">PTOS/SPM Engine</a></h3>
+                    <p>A game engine that I'm helping to make.</p>
                 </div>
             </div>
             <b>My Contributions</b>


### PR DESCRIPTION
# Resizing Fixes

Fixed issues with content vertically overflowing on cards (especially card 2) by setting `overflow-y: auto` on all cards.

# Card 2 Additions

Added a group for the [PTOS/SPM Engine](https://github.com/PTOS-SPM/PTOS-SPM-Engine/tree/dev) since I've started working on that again.